### PR TITLE
removed test_header_controller from imports in index.js

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,6 +6,3 @@ import { application } from "./application"
 
 import HeaderController from "./header_controller"
 application.register("header", HeaderController)
-
-import TestHeaderController from "./test_header_controller"
-application.register("test-header", TestHeaderController)


### PR DESCRIPTION
This is a simple fix to the non existent import of test_header_controller.