### PR TITLE
add img url to listings table

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,7 +23,7 @@
                 input_html: { autocomplete: "new-password" } %>
   </div>
   <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
+    <%= f.button :submit, "Sign up", class:"btn"%>
   </div>
 <% end %>
 <%= render "devise/shared/links" %>

--- a/db/migrate/20230314043056_add_img_url_to_listings.rb
+++ b/db/migrate/20230314043056_add_img_url_to_listings.rb
@@ -1,0 +1,5 @@
+class AddImgUrlToListings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :listings, :img_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_13_082947) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_14_043056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_13_082947) do
     t.bigint "owner_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "img_url"
     t.index ["owner_id"], name: "index_listings_on_owner_id"
   end
 


### PR DESCRIPTION
# Description
​
Adds img_url column to listings table, so that listings will have an img attribute attached to it.
​
Fixes # (missing img for listing)
​

​
Please delete options that are not relevant.
​
- [x] New feature (non-breaking change which adds functionality)
​
# How Has This Been Tested?
​rails console was run and img url attribute was added to listing instance
​
# Checklist:
​
- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
