### PR TITLE
Added img_url column to Users table

### DIFF
--- a/db/migrate/20230314044320_add_img_url_column_to_users.rb
+++ b/db/migrate/20230314044320_add_img_url_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddImgUrlColumnToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :img_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_14_043056) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_14_044320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_14_043056) do
     t.datetime "updated_at", null: false
     t.string "first_name"
     t.string "last_name"
+    t.string "img_url"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# Description
​
Added img_url column to users table, so that user instance will have a img url attribute attached to it
​
Fixes # (users doesnt have img_url attribute)
​
Created migration to add img_url column to users table
​
Please delete options that are not relevant.
​
- [x] New feature (non-breaking change which adds functionality)
​
# How Has This Been Tested?
​
Rails console, to check if users instance has an img_url attribute
​
# Checklist:
​
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
