### PR TITLE
hide sign up and sign in links when user is already signed in

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -115,8 +115,8 @@
                       data-transition-leave-end="transform opacity-0 scale-95"
                     >
               <!-- Active: "bg-gray-100", Not Active: "" -->
-              <a href="<%= new_user_registration_path %>" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="user-menu-item-0">Sign up<a>
-                  <a href="<%= new_user_session_path %>" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="user-menu-item-1">Log in</a>
+              <% unless user_signed_in? %><a href="<%= new_user_registration_path %>" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="user-menu-item-0">Sign up<a><% end %>
+                  <% unless user_signed_in? %><a href="<%= new_user_session_path %>" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="user-menu-item-1">Log in</a><% end %>
                   <% if user_signed_in? %><%= link_to "Logout", destroy_user_session_path, data: { "turbo-method": :delete }, class:"block px-4 py-2 text-sm text-gray-700"%> <% end %>
                 </div>
               </button>


### PR DESCRIPTION
# Description
​
Hides the sign up and sign in link on the drop down when the user is currently signed in
​
Fixes # (displays sign up sign in link even when user is already signed in)

- [ ] Bug fix (non-breaking change which fixes an issue)
​
# How Has This Been Tested?

- [ ] Screenshot A
<img width="316" alt="Screenshot 2023-03-15 at 3 03 49 PM" src="https://user-images.githubusercontent.com/123551406/225232016-31a58e66-123d-4e7f-ab75-7314d5079a24.png">
​
# Checklist:
​
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
