### PR TITLE
added ability to upload avatar when user signs up, display avatar on …

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,9 @@ class ApplicationController < ActionController::Base
   # end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name img_url])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name img_url photo])
 
-    devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name img_url])
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name img_url photo])
   end
 
   private

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -29,13 +29,14 @@
         <%= f.input :password,
               required: true,
               label: false,
-              input_html: { autocomplete: "new-password", placeholder: "Password", class: "rounded-lg border z-0 w-full py-2 px-3 text-gray-700 focus:outline-none focus:shadow-outline" } %>
-        <%= f.input :img_url,
-              required: true,
-              label: false,
-              input_html: { autocomplete: "img_url", placeholder: "Picture Url", class: "rounded-lg border z-0 w-full py-2 px-3 text-gray-700 focus:outline-none focus:shadow-outline" } %>
-        <p class="text-xs text-gray-400 mb-5">Enter your profile picture Img Url</p>
-        <%= f.button :submit, "Sign Up", id: "submit", class: "rounded-lg border z-0 w-full py-2 px-3 text-gray-700 focus:outline-none focus:shadow-outline"%>
+              input_html: { autocomplete: "new-password", placeholder: "Password", class: "rounded-lg border z-0 w-full py-2 px-3 mb-2 text-gray-700 focus:outline-none focus:shadow-outline" } %>
+        <label class="rounded-lg border z-0 w-full bg-gray-100 py-2 px-3 inline-block focus:outline-none focus:shadow-outline text-center" style="color: #9EA6B1;">
+          Upload a Profile Photo
+          <span style="display:none;">
+            <%= f.input :photo, as: :file, required: true %>
+          </span>
+        </label>
+        <%= f.button :submit, "Sign Up", id: "submit", class: "rounded-lg border z-0 w-full py-2 px-3 mt-8 text-gray-700 focus:outline-none focus:shadow-outline"%>
         <%= f.error_notification %>
       </div>
     </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -89,8 +89,9 @@
               </svg>
             </div>
             <div class="flex flex-grow-0 flex-shrink-0 h-10 w-12 pl-5">
+              <!-- avatar -->
               <% if user_signed_in? %>
-                <img src="https://source.unsplash.com/random" alt="" class="rounded-full aspect-square align-middle self-center">
+                <%= cl_image_tag current_user.photo.key, crop: :fill, class: "rounded-full aspect-square align-middle self-center" %>
               <% else %>
                 <svg
                             viewBox="0 0 32 32"


### PR DESCRIPTION

# Description
​
Added button to upload profile photo when a user signs up for an account.
Avatar displays in header when user is logged in.
​
Fixes # (issue)
​
## Type of change

- [X] New feature (non-breaking change which adds functionality)
​
# How Has This Been Tested?
​
![usersignup](https://user-images.githubusercontent.com/105141510/225518636-61952a27-8099-43f0-bffb-920be86ddb20.jpg)
Button for User to upload profile photo

![headeravatar](https://user-images.githubusercontent.com/105141510/225518641-68e08c89-580b-416c-9cbd-dc154ffe2991.jpg)
Profile photo of logged in user

​
# Checklist:
​
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
