### PR TITLE
Added logic to make sure rails doesnt throw error when user.photo.key is nil

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -90,7 +90,7 @@
             </div>
             <div class="flex flex-grow-0 flex-shrink-0 h-10 w-12 pl-5">
               <!-- avatar -->
-              <% if user_signed_in? %>
+              <% if user_signed_in? && current_user.photo.key %>
                 <%= cl_image_tag current_user.photo.key, crop: :fill, class: "rounded-full aspect-square align-middle self-center" %>
               <% else %>
                 <svg


### PR DESCRIPTION


# Description
​
added additional condition when displaying user profile picture on the drop down menu, so that it will display default picture if user photo doesnt exist.
​
Fixes # (rails webpage error)
​
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] Screenshot A
​
<img width="310" alt="Screenshot 2023-03-16 at 2 52 41 PM" src="https://user-images.githubusercontent.com/123551406/225537943-465fb574-c2c4-41cf-9eac-fe43edd4a9fa.png">

# Checklist:
​
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
