### PR TITLE
change object-fit of profile photos

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -91,7 +91,7 @@
             <div class="flex flex-grow-0 flex-shrink-0 h-10 w-12 pl-5">
               <!-- avatar -->
               <% if user_signed_in? && current_user.photo.key %>
-                <%= cl_image_tag current_user.photo.key, crop: :fill, class: "rounded-full aspect-square align-middle self-center" %>
+                <%= cl_image_tag current_user.photo.key, crop: :fill, class: "object-cover rounded-full aspect-square align-middle self-center" %>
               <% else %>
                 <svg
                             viewBox="0 0 32 32"

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -39,7 +39,7 @@
           <%# OWNER AVATAR %>
           <div class="w-14">
             <% if @listing.owner.photo.key %>
-              <%= cl_image_tag @listing.owner.photo.key, crop: :fill, class: "rounded-full aspect-square align-middle self-center" %>
+              <%= cl_image_tag @listing.owner.photo.key, crop: :fill, class: " object-cover rounded-full aspect-square align-middle self-center" %>
             <% else %>
                 <svg
                             viewBox="0 0 32 32"


### PR DESCRIPTION
# Description
​
Changed Profile Photos to object-fit without being stretched.
​
Fixes #91  (issue)
​
## Type of change
​
- [X] Bug fix (non-breaking change which fixes an issue)
​
# How Has This Been Tested?
​
<img width="323" alt="Screenshot 2023-03-16 at 5 03 38 PM" src="https://user-images.githubusercontent.com/105141510/225567735-89cbc623-4b4c-4f96-8b15-72f7053a866c.png">
- [X] Logged in user Profile Photo

<img width="635" alt="Screenshot 2023-03-16 at 5 03 34 PM" src="https://user-images.githubusercontent.com/105141510/225567765-200fdfdc-f510-4a2e-a50b-8d9c81360483.png">
- [X] Owner's Profile Photo
​
# Checklist:
​
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
