### PR TITLE
add dependent destroy to all bookings on a listing

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -1,5 +1,5 @@
 class Listing < ApplicationRecord
-  has_many :bookings
+  has_many :bookings, dependent: :destroy
   belongs_to :owner, class_name: "User", foreign_key: "owner_id"
   geocoded_by :address
   after_validation :geocode, if: :will_save_change_to_address?


### PR DESCRIPTION
# Description
​
Add dependent: :destroy on Listing model, to destroy all :bookings when a listing is deleted.
​
Fixes # (issue)
​
## Type of change
​
Please delete options that are not relevant.
​
- [X] Bug fix (non-breaking change which fixes an issue)
​
# How Has This Been Tested?
​
Tested on my machine.
​
